### PR TITLE
Open Table Data

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -36,6 +36,7 @@
     <button class="button" id="installFromAppSource">Install Extension From Appsource</button>
     <button class="button" id="openInVSCode" type="button">Open VS Code</button>
     <button class="button" id="openExtMgt" type="button">View 3rd party Ext.</button>
+    <button class="button" id="openTableData" type="button">Open Table Data</button>
 
     <script src="popup.js"></script>
 </body>

--- a/popup.js
+++ b/popup.js
@@ -57,3 +57,30 @@ function openInVSCode() {
         window.open(`vscode://ms-dynamics-smb.al/navigateTo?type=page&id=${pageID}&environmentType=Sandbox&environmentName=${sandboxName}&tenant=${tenantID}`)
     })
 }
+
+document.getElementById("openTableData").addEventListener("click", openTableData);
+
+function openTableData() {
+    chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+        var activeTab = tabs[0];
+        var urlObj = new URL(activeTab.url);
+
+        const params = new Proxy(new URLSearchParams(urlObj.search), {
+            get: (searchParams, prop) => searchParams.get(prop),
+        });
+        let company = '';
+        if (params.company) {
+            company = `&company=${params.company}`;
+        }
+        let tenant = `tenant=${params.tenant}`;
+        if (urlObj.origin = 'https://businesscentral.dynamics.com/') {
+            tenant = '';
+        }
+
+        var tableID = prompt("Please enter the table ID you want to open");
+        if (tableID != null) {
+            let myNewUrl = `${urlObj.origin}${urlObj.pathname}?${tenant}${company}&Table=${tableID}`;
+            window.open(myNewUrl)
+        }
+    })
+}


### PR DESCRIPTION
Hello,

First of all, I want to express how useful this tool has been. If there is no inconvenience, I would like to add a little new functionality.

I am not a JavaScript expert, in fact, I know very little about it. Basically, to implement the new functionality, I copied a part of the code you already had and made a couple of small changes.

Use case:
Often, during development, I need to functionally display the entire contents of a table.

Example:
When I develop something that involves tables 336 and 337.

As I'm a bit lazy and prefer not to manually modify the URL every time I want to display the data of those tables, I thought to modify your extension :) add a button along the same lines. 
![image](https://github.com/StefanMaron/OpenPageInspection/assets/21259250/f98d0e04-8dfa-4fb4-ad12-ff9131de1335)

This button asks for the table ID and opens the URL in a new tab. I'm not sure if it will be very useful for others, but it worked for me.
![image](https://github.com/StefanMaron/OpenPageInspection/assets/21259250/7d2e57af-8e53-448e-8f2d-db0cef99a87b)

Result:
![image](https://github.com/StefanMaron/OpenPageInspection/assets/21259250/8b0f26bd-a4f8-41db-8d4a-77df0ab45a49)

Thank you very much and best regards.